### PR TITLE
Updates

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload entire repository
           path: '.'

--- a/publications.html
+++ b/publications.html
@@ -134,3 +134,4 @@ function w3_close() {
 </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the Pages artifact upload action version in CI and ensure a trailing newline in the publications page

CI:
- Upgrade actions/upload-pages-artifact action from v1 to v4 in static.yml

Chores:
- Add a missing newline at the end of publications.html